### PR TITLE
Changes to blood system and items

### DIFF
--- a/Advanced Medicine/Afflictions.xml
+++ b/Advanced Medicine/Afflictions.xml
@@ -642,16 +642,18 @@
     indicatorlimb="Torso"
     activationthreshold="0"
     maxstrength="100">
-    <Effect minstrength="0" maxstrength="15" multiplybymaxvitality="true"
+    <Effect minstrength="0" maxstrength="25" multiplybymaxvitality="false"
       dialogflag="Bloodloss"/>
-    <Effect minstrength="25" maxstrength="45" multiplybymaxvitality="true"
+    <Effect minstrength="25" maxstrength="45" multiplybymaxvitality="false"
+	  strengthchange="-0.1"
       dialogflag="Bloodloss">
       <StatusEffect target="character">
       <Conditional afsaline="eq 0"/>
       <Affliction identifier="hypotension" amount="0.3"/>
       </StatusEffect>
     </Effect>
-    <Effect minstrength="45" maxstrength="75" multiplybymaxvitality="true"
+    <Effect minstrength="45" maxstrength="80" multiplybymaxvitality="false"
+	  strengthchange="-0.1"
       dialogflag="Bloodloss">
       <StatusEffect target="Character" SpeedMultiplier="0.3" setvalue="true"/>
       <StatusEffect target="character">
@@ -666,7 +668,8 @@
       <Affliction identifier="hypoxia" amount="0.05"/>
       </StatusEffect>
     </Effect>
-    <Effect minstrength="75" maxstrength="100" multiplybymaxvitality="true"
+    <Effect minstrength="80" maxstrength="100" multiplybymaxvitality="false"
+	  strengthchange="-0.1"
       dialogflag="Bloodloss">
       <StatusEffect target="character">
       <Affliction identifier="oxygenlow" amount="3"/>
@@ -680,11 +683,10 @@
       <Affliction identifier="hypoxia" amount="0.3"/>
       </StatusEffect>
       <StatusEffect target="character" disabledeltatime="true" comparison="And">
-      <Conditional asys="eq 0" vf="eq 0" afsaline="eq 0"/>
-      <Affliction identifier="asys" amount="5" probability="0.03"/>
+      <Conditional asys="eq 0" vf="eq 0" afsaline="lt 75"/>
+      <Affliction identifier="vt" amount="5" probability="0.1"/>
       </StatusEffect>
     </Effect>
-
     <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,768,128,128" color="139,60,42,255" origin="0,0"/>
   </Bloodloss>
   </Override>
@@ -1297,39 +1299,6 @@
     showiconthreshold="200"
     maxstrength="100">
     <Effect minstrength="0" maxstrength="100" strengthchange="-0.2"/>
-    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,896,128,128" color="10,193,114,255" origin="0,0"/>
-  </Affliction>
-  
-  <Affliction
-    name="Blood bank"
-    identifier="bloodbank"
-    description=""
-    type="resistance"
-    isbuff="true"
-    limbspecific="false"
-    showiconthreshold="200"
-    maxstrength="100">
-    <Effect minstrength="0" maxstrength="2" strengthchange="15"/>
-    <Effect minstrength="2" maxstrength="4" strengthchange="0.01"/>
-    <Effect minstrength="4" maxstrength="5" strengthchange="0.01">
-    <StatusEffect target="Character">
-    <Conditional bloodloss="gt 0"/>
-    <ReduceAffliction identifier="bloodloss" amount="0.01"/>
-    <ReduceAffliction identifier="bloodbank" amount="0.01"/>
-    </StatusEffect>
-    </Effect>
-    <Effect minstrength="5" maxstrength="100" delay="3" strengthchange="0.015">
-    <StatusEffect target="Character">
-    <Conditional bloodloss="gt 0"/>
-    <ReduceAffliction identifier="bloodloss" amount="0.5"/>
-    <ReduceAffliction identifier="bloodbank" amount="0.35"/>
-    </StatusEffect>
-    <StatusEffect target="Character" delay="30">
-    <Conditional bloodloss="gte 15"/>
-    <ReduceAffliction identifier="bloodloss" amount="1"/>
-    <ReduceAffliction identifier="bloodbank" amount="0.75"/>
-    </StatusEffect>
-    </Effect>
     <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,896,128,128" color="10,193,114,255" origin="0,0"/>
   </Affliction>
 

--- a/Advanced Medicine/Characters/Human/Human.xml
+++ b/Advanced Medicine/Characters/Human/Human.xml
@@ -14,10 +14,6 @@
   <Conditional immunity="eq 0"/>
     <Affliction identifier="immunity" amount="600" />
   </StatusEffect>
-  <StatusEffect tags="bloodbank" type="always" target="This" disabledeltatime="true" comparison="And">
-  <Conditional bloodbank="eq 0"/>
-    <Affliction identifier="bloodbank" amount="100" />
-  </StatusEffect>
 
   <StatusEffect tags="bloodgroup" type="always" target="This" comparison="And" random="true">
   <Conditional aplus="eq 0" bplus="eq 0" abplus="eq 0" aminus="eq 0" bminus="eq 0" abminus="eq 0" ominus="eq 0" oplus="eq 0"/>

--- a/Advanced Medicine/items.xml
+++ b/Advanced Medicine/items.xml
@@ -86,11 +86,11 @@
       </StatusEffect>
       <StatusEffect type="OnUse" target="This" Condition="-100" />
       <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="1" stackable="false" />
-      <StatusEffect type="OnUse" target="Contained,Character" Condition="-0.5" comparison="Or">
+      <StatusEffect type="OnUse" target="Contained,Character" Condition="-2" comparison="Or">
         <Conditional IsDead="false" />
         <RequiredItem items="oxygentank" type="Contained" />
       </StatusEffect>
-      <StatusEffect type="OnUse" target="Contained,Character" Condition="-0.1" comparison="Or">
+      <StatusEffect type="OnUse" target="Contained,Character" Condition="-0.5" comparison="Or">
         <Conditional IsDead="false" />
         <RequiredItem items="oxygenitetank" type="Contained" />
       </StatusEffect>
@@ -1307,13 +1307,13 @@
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <RequiredSkill identifier="medical" level="10" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="20">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="10">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <Affliction identifier="afsaline" amount="25" />
+        <Affliction identifier="afsaline" amount="5" />
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="20">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="10">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <Affliction identifier="afsaline" amount="17" />
+        <Affliction identifier="afsaline" amount="3" />
       </StatusEffect>
       <!-- Remove the item when fully used -->
       <StatusEffect type="OnBroken" target="This">
@@ -1354,15 +1354,13 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <!-- Remove the item when fully used -->
       <StatusEffect type="OnBroken" target="This">
@@ -1391,19 +1389,17 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
         <Conditional aminus="gt 0" bminus="gt 0" abminus="gt 0" ominus="gt 0"/>
         <Affliction identifier="hemotransfusionshock" amount="0.1"/>
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
         <Conditional aminus="gt 0" bminus="gt 0" abminus="gt 0" ominus="gt 0"/>
@@ -1434,19 +1430,17 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
         <Conditional aminus="gt 0" bminus="gt 0" bplus="gt 0" abminus="gt 0" oplus="gt 0" ominus="gt 0"/>
         <Affliction identifier="hemotransfusionshock" amount="0.1"/>
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
         <Conditional aminus="gt 0" bminus="gt 0" bplus="gt 0" abminus="gt 0" oplus="gt 0" ominus="gt 0"/>
@@ -1477,19 +1471,17 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
         <Conditional aminus="gt 0" bminus="gt 0" aplus="gt 0" abminus="gt 0" oplus="gt 0" ominus="gt 0"/>
         <Affliction identifier="hemotransfusionshock" amount="0.1"/>
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
         <Conditional aminus="gt 0" bminus="gt 0" aplus="gt 0" abminus="gt 0" oplus="gt 0" ominus="gt 0"/>
@@ -1518,19 +1510,17 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
         <Conditional aplus="eq 0" bplus="eq 0" aminus="eq 0" bminus="eq 0" abminus="eq 0" ominus="eq 0" oplus="eq 0"/>
         <Affliction identifier="hemotransfusionshock" amount="0.1"/>
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
         <Conditional aplus="eq 0" bplus="eq 0" aminus="eq 0" bminus="eq 0" abminus="eq 0" ominus="eq 0" oplus="eq 0"/>
@@ -1561,19 +1551,17 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
         <Conditional bminus="gt 0" bplus="gt 0" oplus="gt 0" ominus="gt 0"/>
         <Affliction identifier="hemotransfusionshock" amount="0.1"/>
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
         <Conditional bminus="gt 0" bplus="gt 0" oplus="gt 0" ominus="gt 0"/>
@@ -1604,19 +1592,17 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
         <Conditional aminus="gt 0" aplus="gt 0" oplus="gt 0" ominus="gt 0"/>
         <Affliction identifier="hemotransfusionshock" amount="0.1"/>
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
         <Conditional aminus="gt 0" aplus="gt 0" oplus="gt 0" ominus="gt 0"/>
@@ -1645,19 +1631,17 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="8" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
         <Conditional aplus="eq 0" bplus="eq 0" aminus="eq 0" bminus="eq 0" ominus="eq 0" oplus="eq 0"/>
         <Affliction identifier="hemotransfusionshock" amount="0.1"/>
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="8" />
+        <ReduceAffliction identifier="bloodloss" amount="2" />
       </StatusEffect>
       <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
         <Conditional aplus="eq 0" bplus="eq 0" aminus="eq 0" bminus="eq 0" ominus="eq 0" oplus="eq 0"/>
@@ -1716,16 +1700,14 @@
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true" />
       <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
-      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="4" />
-        <Affliction identifier="bloodbank" amount="4" />
+        <ReduceAffliction identifier="bloodloss" amount="3" />
         <Affliction identifier="drunk" amount="6" />
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="15">
+      <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
         <ReduceAffliction identifier="bloodloss" amount="2" />
-        <Affliction identifier="bloodbank" amount="2" />
         <Affliction identifier="drunk" amount="8" />
       </StatusEffect>
       <!-- Remove the item when fully used -->
@@ -1755,49 +1737,47 @@
     <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
       <RequiredSkill identifier="medical" level="35" />
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional aplus="gt 0" bloodbank="gte 85"/>
+      <Conditional aplus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="bloodpackaplus"/>
       </StatusEffect>
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional bplus="gt 0" bloodbank="gte 85"/>
+      <Conditional bplus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="bloodpackbplus"/>
       </StatusEffect>
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional oplus="gt 0" bloodbank="gte 85"/>
+      <Conditional oplus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="bloodpackoplus"/>
       </StatusEffect>
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional abplus="gt 0" bloodbank="gte 85"/>
+      <Conditional abplus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="bloodpackabplus"/>
       </StatusEffect>
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional aminus="gt 0" bloodbank="gte 85"/>
+      <Conditional aminus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="bloodpackaminus"/>
       </StatusEffect>
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional bminus="gt 0" bloodbank="gte 85"/>
+      <Conditional bminus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="bloodpackbminus"/>
       </StatusEffect>
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional abminus="gt 0" bloodbank="gte 85"/>
+      <Conditional abminus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="bloodpackabminus"/>
       </StatusEffect>
       <StatusEffect type="OnUse" target="This, Character" comparison="And">
-      <Conditional ominus="gt 0" bloodbank="gte 85"/>
+      <Conditional ominus="gt 0" bloodloss="lt 30"/>
       <SpawnItem identifier="antibloodloss2"/>
       </StatusEffect>
-      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+      <StatusEffect type="OnUse" target="This" Condition="-100"  disabledeltatime="true"/>
       <StatusEffect tags="medical" type="OnUse" target="Character, This">
-      <Conditional bloodbank="gte 85"/>
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-        <Affliction identifier="bloodloss" amount="20" />
-        <ReduceAffliction identifier="bloodbank" amount="80" />
+        <Conditional bloodloss="lt 30"/>
+        <Affliction identifier="bloodloss" amount="33" />
       </StatusEffect>
-      <StatusEffect tags="medical" type="OnFailure" target="Character, This">
-      <Conditional bloodbank="gte 85"/>
+      <StatusEffect tags="medical" type="OnFailure" Condition="-50.0" target="Character, This">
         <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-        <ReduceAffliction identifier="bloodloss" amount="30" />
-        <Affliction identifier="bloodbank" amount="100" />
+        <Conditional bloodloss="lt 30"/>
+        <Affliction identifier="bloodloss" amount="40" />
       </StatusEffect>
       <StatusEffect type="OnBroken" target="This">
         <Remove />


### PR DESCRIPTION
Blood works now as before but with higher caps:
At 80% character will suffer from the effects of hypovolemic shock which means dropping blood-pressure (hypotension) and V-Tach (as pulse is usually around 150+).

Effects of bloodloss can be combated with saline or blood-tranfusions.

Empty Blood Packs only produce a bloodpack when the character has below 30% bloodloss.
Every blood tranfusion will cause 33% bloodloss, blood-packs themselves will all restore 33% blood if medical skill check has been met.

To-Do: Not consume the blood-kit when conditions are not met.

Smaller Changes:
>BVM uses 2% of an oxygen tank and 0.5% of oxygenite during use. (Balance-question: Maybe increasing time in between uses so it's not suddenly a make-shift mask? Thoughts)

>Saline causes 50% of its infliction to balance its high use and low cost.