### PR TITLE
Quick localizations review

### DIFF
--- a/Advanced Medicine/Localization/English.xml
+++ b/Advanced Medicine/Localization/English.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <infotexts language="English" nowhitespace="false" translatedname="English">
 
+<!-- MESSAGES -->
+	<stasisbugequipconfirmation>Are you sure you want put stasis bag on yourself?</stasisbugequipconfirmation>
 <!-- ITEMS -->
 
 	<entityname.aed>Automated External Defibrillator</entityname.aed>
@@ -10,31 +12,34 @@
 	<entitydescription.advscalpel>A tool used to make incisions during surgery.</entitydescription.advscalpel>
 	
 	<entityname.advhemostat>Hemostat</entityname.advhemostat>
-	<entitydescription.advhemostat>A tool used to clamp bleeders during surgery.</entitydescription.advhemostat>
-	
-	<entityname.surgicaldrill>Surgical drill</entityname.surgicaldrill>
-	<entitydescription.surgicaldrill>A tool used to drill bones.</entitydescription.surgicaldrill>
-	
-	<entityname.osteosynthesisimplants>Osteosynthesis Implants</entityname.osteosynthesisimplants>
-	<entitydescription.osteosynthesisimplants>Titanium implants used in an open reduction surgery to repair fractures.</entitydescription.osteosynthesisimplants>
-	
+	<entitydescription.advhemostat>A tool used to clamp blood vessels during surgery.</entitydescription.advhemostat>
+
 	<entityname.advretractors>Retractors</entityname.advretractors>
 	<entitydescription.advretractors>A tool used to retract skin during surgery.</entitydescription.advretractors>
-		
+
+	<entityname.autocpr>AutoPulse</entityname.autocpr>
+	<entitydescription.autocpr>An automated, portable, battery-powered cardiopulmonary resuscitation device.</entitydescription.autocpr>
+	
+	<entityname.bvm>Ambu bag</entityname.bvm>
+	<entitydescription.bvm>A bag valve mask (BVM), is a hand-held device commonly used to provide positive pressure ventilation to patients who are not breathing or not breathing adequately.</entitydescription.bvm>
+
+	<entityname.stasisbag>Stasis bag</entityname.stasisbag>
+	<entitydescription.stasisbag>Stops biological processes and protects against cerebral hypoxia.</entitydescription.stasisbag>
+
 	<entityname.surgerysaw>Surgical Saw</entityname.surgerysaw>
 	<entitydescription.surgerysaw>A tool used to saw through bones.</entitydescription.surgerysaw>		
 	
 	<entityname.suture>Suture</entityname.suture>
 	<entitydescription.suture>Biodegradeable sutures for stitching up lacerations and surgical incisions alike.</entitydescription.suture>
-	
-	<entityname.tweezers>Tweezers</entityname.tweezers>
-	<entitydescription.tweezers>A small tool that allows the removal of bullets as well as damaged and necrotic tissue.</entitydescription.tweezers>
 
-	<entityname.tourniquet>Tourniquet</entityname.tourniquet>
-	<entitydescription.tourniquet>A device that applies pressure to a limb and thus reduces bloodflow. It is usually used in case of major bleeders on extremities.</entitydescription.tourniquet>
+	<entityname.surgicaldrill>Surgical drill</entityname.surgicaldrill>
+	<entitydescription.surgicaldrill>A tool used to drill bones.</entitydescription.surgicaldrill>
 
 	<entityname.mannitol>Mannitol Plus</entityname.mannitol>
-	<entitydescription.mannitol>A highly complicated and expensive medicinal compound which stimulates the regeneration of neurological tissue. </entitydescription.mannitol>
+	<entitydescription.mannitol>A highly complicated and expensive medicinal compound which stimulates the regeneration of neurological tissue.</entitydescription.mannitol>
+	
+	<entityname.osteosynthesisimplants>Osteosynthesis Implants</entityname.osteosynthesisimplants>
+	<entitydescription.osteosynthesisimplants>Titanium implants used in an open reduction surgery to repair fractures.</entitydescription.osteosynthesisimplants>
 	
 	<entityname.operatingtable>Operating table</entityname.operatingtable>
 	<entitydescription.operatingtable>An operation table which has basic artificial ventilation built in.</entitydescription.operatingtable>
@@ -42,7 +47,17 @@
 	<entityname.ointment>Antibiotic ointment</entityname.ointment>
 	<entitydescription.ointment>A highly antiseptic gel that promotes the recovery from burns as well as from minor infections.</entitydescription.ointment>
 
+	<entityname.tweezers>Tweezers</entityname.tweezers>
+	<entitydescription.tweezers>A small tool that allows the removal of bullets as well as damaged and necrotic tissue.</entitydescription.tweezers>
+
+	<entityname.tourniquet>Tourniquet</entityname.tourniquet>
+	<entitydescription.tourniquet>A device that applies pressure to a limb and thus reduces bloodflow. It is usually used in case of major bleeders on extremities.</entitydescription.tourniquet>
 	
+	<entityname.vialrack>Test tube rack</entityname.vialrack>
+	<entitydescription.vialrack>Rack for storing test tubes and vials.</entitydescription.vialrack>
+
+	<entityname.bloodanalyzer>Hematology analyzer</entityname.bloodanalyzer>
+	<entityname.bloodanalyzer>Blood typing device. Fully automated.</entityname.bloodanalyzer>
 	<!-- AFFLICTIONS -->
 	
 	
@@ -68,8 +83,8 @@
 	<afflictiondescription.hypotension>Pulse strength has become weaker.</afflictiondescription.hypotension>
 	
 	<afflictionname.hypoxia>Cerebral Hypoxia</afflictionname.hypoxia>
-	<afflictiondescription.hypoxia>Patient is showing signs of nerve and braindamage.</afflictiondescription.hypoxia>
-	<afflictioncauseofdeath.hypoxia>Braindead</afflictioncauseofdeath.hypoxia>
+	<afflictiondescription.hypoxia>Patient is showing signs of nerve and brain damage.</afflictiondescription.hypoxia>
+	<afflictioncauseofdeath.hypoxia>Brain dead</afflictioncauseofdeath.hypoxia>
 	<afflictioncauseofdeathself.hypoxia>You have died of Cerebral Hypoxia.</afflictioncauseofdeathself.hypoxia>
 	
 	<afflictionname.surgeryincision>Surgery incision</afflictionname.surgeryincision>

--- a/Advanced Medicine/Localization/Russian.xml
+++ b/Advanced Medicine/Localization/Russian.xml
@@ -1,14 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <infotexts language="Russian" nowhitespace="false" translatedname="Русский">
 
+	<!-- MESSAGES -->
+	<stasisbugequipconfirmation>Вы уверены что хотите надеть на себя стазисную сумку?</stasisbugequipconfirmation>
+	
+	<!-- ITEMS -->
 	<entityname.aed>Автоматический наружный дефибриллятор</entityname.aed>
-	<entitydescription.aed>Устройство, которое производит контролируемый шок для лечения остановки сердца.</entitydescription.aed>
+	<entitydescription.aed>Устройство, которое стабилизирует сердце электрическим ударом. Использовать на пациентах с тахикардией желудочков или фибрилляцией.</entitydescription.aed>
 	
 	<entityname.advscalpel>Скальпель</entityname.advscalpel>
 	<entitydescription.advscalpel>Инструмент, используемый для надрезов во время операции.</entitydescription.advscalpel>
 	
 	<entityname.advhemostat>Зажим</entityname.advhemostat>
 	<entitydescription.advhemostat>Инструмент, используемый для остановки кровотечения во время операции.</entitydescription.advhemostat>
+
+	<entityname.advretractors>Расширитель</entityname.advretractors>
+	<entitydescription.advretractors>Инструмент, используемый для оттягивания кожи во время операции.</entitydescription.advretractors>
+
+	<entityname.autocpr>АвтоПульс</entityname.autocpr>
+	<entitydescription.autocpr>Портативное устройство на батарейках, производящее автоматический непрямой массаж сердца.</entitydescription.autocpr>
+
+	<entityname.bvm>Мешок Амбу</entityname.bvm>
+	<entitydescription.bvm>Портативная маска для проведения искусственной вентиляции легких с помощью позитивного давления.</entitydescription.bvm>
+
+	<entityname.stasisbag>Стазис-мешок</entityname.stasisbag>
+	<entitydescription.stasisbag>Останавливает биологические процессы и защищает от церебральной гипоксии.</entitydescription.stasisbag>
 	
 	<entityname.surgicaldrill>Хирургическая дрель</entityname.surgicaldrill>
 	<entitydescription.surgicaldrill>Инструмент, используемый для сверления костей.</entitydescription.surgicaldrill>
@@ -16,9 +32,6 @@
 	<entityname.osteosynthesisimplants>Имплантаты для остеосинтеза</entityname.osteosynthesisimplants>
 	<entitydescription.osteosynthesisimplants>Титановые имплантаты для остеосинтеза.</entitydescription.osteosynthesisimplants>
 	
-	<entityname.advretractors>Расширитель</entityname.advretractors>
-	<entitydescription.advretractors>Инструмент, используемый для оттягивания кожи во время операции.</entitydescription.advretractors>
-		
 	<entityname.surgerysaw>Хирургическая пила</entityname.surgerysaw>
 	<entitydescription.surgerysaw>Инструмент, используемый для распиливания костей.</entitydescription.surgerysaw>		
 	
@@ -39,6 +52,14 @@
 
 	<entityname.ointment>Антибиотическая мазь</entityname.ointment>
 	<entitydescription.ointment>Используется для лечения ожогов и инфекций.</entitydescription.ointment>
+	
+	<entityname.vialrack>Стойка для пробирок</entityname.vialrack>
+	<entitydescription.vialrack>Стойка для хранения пробирок и образцов крови.</entitydescription.vialrack>
+
+	<entityname.bloodanalyzer>Гематологический анализатор</entityname.bloodanalyzer>
+	<entityname.bloodanalyzer>Прибор для определения группы крови. Полностью автоматический.</entityname.bloodanalyzer>
+
+
 	
 	<!-- AFFLICTIONS -->
 	
@@ -62,7 +83,7 @@
 	<afflictiondescription.asys>Отсутствует электрическая активность в сердечных мышцах.</afflictiondescription.asys>
 	
 	<afflictionname.hypotension>Гипотония</afflictionname.hypotension>
-	<afflictiondescription.hypotension>Сила пульса стала слабее.</afflictiondescription.hypotension>
+	<afflictiondescription.hypotension>Пульс стал слабее.</afflictiondescription.hypotension>
 	
 	<afflictionname.hypoxia>Церебральная гипоксия</afflictionname.hypoxia>
 	<afflictiondescription.hypoxia>У пациента наблюдаются признаки повреждения нервов и головного мозга.</afflictiondescription.hypoxia>
@@ -97,7 +118,7 @@
 	<afflictiondescription.boncut>Кости разрезаны пилой.</afflictiondescription.boncut>
 	
 	<afflictionname.fracture>Перелом</afflictionname.fracture>
-	<afflictiondescription.fracture>Одна или несколько костей сломаны и вызывают сильную боль и проблемы с опорно-двигательным аппаратом.</afflictiondescription.fracture>
+	<afflictiondescription.fracture>Одна или несколько костей сломаны и вызывают сильную боль также наблюдаются проблемы с опорно-двигательным аппаратом.</afflictiondescription.fracture>
 	
 	<afflictionname.arterialcut>Артериальное кровотечение</afflictionname.arterialcut>
 	<afflictiondescription.arterialcut>Кровь льётся из артерии.</afflictiondescription.arterialcut>
@@ -107,12 +128,9 @@
 		
 	<afflictionname.anesthesia>Анестезия</afflictionname.anesthesia>
 	<afflictiondescription.anesthesia>Пациент не чувствителен к боли.</afflictiondescription.anesthesia>
-	
-	<afflictionname.anesthesia>Анестезия</afflictionname.anesthesia>
-	<afflictiondescription.anesthesia>Пациент не чувствителен к боли.</afflictiondescription.anesthesia>
 
 	<afflictionname.necrosis>Некроз</afflictionname.necrosis>
-	<!-- <afflictiondescription.necrosis></afflictiondescription.necrosis> -->
+	<!-- <afflictiondescription.necrosis>Мёртвые ткани медленно накапливаются и приводят к опасным для жизни последствиям.</afflictiondescription.necrosis> -->
 	<afflictioncauseofdeath.necrosis>Умер от некроза.</afflictioncauseofdeath.necrosis>
 	<afflictioncauseofdeathself.necrosis>Вы умерли от некроза.</afflictioncauseofdeathself.necrosis>
 

--- a/Advanced Medicine/Xml/items.xml
+++ b/Advanced Medicine/Xml/items.xml
@@ -2032,7 +2032,7 @@
   <Item name="Blood analyzer" description="Blood typing device" identifier="bloodanalyzer" category="Equipment" useinhealthinterface="true" cargocontaineridentifier="metalcrate" tags="smallitem" impactsoundtag="impact_soft" scale="0.5" hideconditionbar="true">
 =======
 
-  <Item name="" identifier="vialrack" scale="0.2" category="Equipment" description="Rack for storing blood collectors and vials" cargocontaineridentifier="metalcrate">
+  <Item name="" identifier="vialrack" scale="0.2" category="Equipment" description="" cargocontaineridentifier="metalcrate">
     <Price baseprice="10">
       <Price locationtype="outpost" multiplier="1" minavailable="2" />
       <Price locationtype="city" multiplier="0.9" minavailable="6" />

--- a/Advanced Medicine/Xml/items.xml
+++ b/Advanced Medicine/Xml/items.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
+
   <Item name="" identifier="aed" category="Equipment" cargocontaineridentifier="chemicalcrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
     <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
     <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3" />
@@ -58,7 +59,7 @@
       </ItemContainer>
   </Item>
   
-  <Item name="Ambu bag" identifier="bvm" category="Equipment" cargocontaineridentifier="chemicalcrate" Tags="smallitem,medical" description="A bag valve mask (BVM), is a hand-held device commonly used to provide positive pressure ventilation to patients who are not breathing or not breathing adequately" useinhealthinterface="True" scale="0.070">
+  <Item name="" identifier="bvm" category="Equipment" cargocontaineridentifier="chemicalcrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.070">
     <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
     <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3" />
     <Fabricate suitablefabricators="fabricator" requiredtime="10">
@@ -597,6 +598,7 @@
 </StatusEffect>
 </MeleeWeapon>
 </Item>
+
 <Override>
 <Item name="" identifier="antidama1" aliases="Corrigodone" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
@@ -675,6 +677,7 @@
     </Projectile>
   </Item>
 </Override>
+
 <Override>
 <Item name="" identifier="antidama2" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
@@ -754,6 +757,7 @@
     </Projectile>
   </Item>
 </Override>
+
 <Override>
 <Item name="" identifier="opium" category="Material" maxstacksize="8" Tags="smallitem,chem" description="" cargocontaineridentifier="mediccrate" scale="0.5" useinhealthinterface="true">
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
@@ -802,6 +806,7 @@
     </MeleeWeapon>
   </Item>
 </Override>
+
 <Override>
 <Item name="" identifier="antibleeding1" aliases="Bandage" category="Equipment" Tags="smallitem,medical" maxstacksize="8" useinhealthinterface="true" cargocontaineridentifier="mediccrate" description="" scale="0.5" impactsoundtag="impact_soft">
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
@@ -857,6 +862,7 @@
     </MeleeWeapon>
   </Item>
 </Override>
+
 <Item name="" identifier="mannitol" category="Material" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" maxstacksize="8" >
     <PreferredContainer primary="medcab" spawnprobability="0.05" />
     <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.25" />
@@ -915,6 +921,7 @@
       </StatusEffect>
     </Projectile>
   </Item>
+
 <Item name="" identifier="operatingtable" scale="0.4" Tags="medical" maxstacksize="1" category="medical" description="" isshootable="true">
     <Upgrade gameversion="0.12.0.0" noninteractable="false" />
     <Body width="416" height="192" density="40" />
@@ -1006,6 +1013,7 @@
       </StatusEffect>
     </MeleeWeapon>
   </Item>
+
   <Override>
   <Item name="" identifier="antibleeding2" category="Equipment" Tags="smallitem,medical" maxstacksize="8" cargocontaineridentifier="mediccrate" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_soft">
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
@@ -1103,7 +1111,6 @@
     <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="-35,3" containedspritedepth="0.56" ItemRotation="-90" containedstateindicatorstyle="tank">
       <Containable items="antiseptic" />
     </ItemContainer>
-
   </Item>
 
   <Item name="Antiseptic" identifier="antiseptic" category="Material" maxstacksize="8" cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,chem,medical" scale="0.3">
@@ -1134,7 +1141,11 @@
     </MeleeWeapon>
   </Item>
   
+<<<<<<< Updated upstream
   <Item name="Stasis Bag" identifier="stasisbag" category="Equipment" tags="provocative" scale="0.5" fireproof="true" description="Stops biological processes and protects against cerebral hypoxia" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft">
+=======
+  <Item name="" identifier="stasisbag" category="Equipment" tags="provocative" scale="0.5" fireproof="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft" equipconfirmationtext="stasisbugequipconfirmation">
+>>>>>>> Stashed changes
     <Price baseprice="2500" soldeverywhere="false">
       <Price locationtype="outpost" multiplier="1.2" sold="false"/>
       <Price locationtype="city" multiplier="1.3" sold="false"/>
@@ -1217,11 +1228,15 @@
       <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="psychosis" damagemultiplier="0.0" damagesound="LimbArmor"/>
     </Wearable>
     <aitarget maxsightrange="50" />
-  
   </Item>
   
+<<<<<<< Updated upstream
   <Item name="Auto-Compression" identifier="autocpt" category="Equipment" tags="smallitem,clothing" scale="0.35" cargocontaineridentifier="metalcrate" description="An automated, portable, battery-powered cardiopulmonary resuscitation" impactsoundtag="impact_soft">
     <Upgrade gameversion="0.9.3.0" scale="0.35" />
+=======
+  <Item name="" identifier="autocpr" category="Equipment" tags="smallitem,clothing" scale="0.40" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_soft">
+    <Upgrade gameversion="0.9.3.0" scale="0.40" />
+>>>>>>> Stashed changes
     <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1" />
     <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.25" />
     <Price baseprice="300" soldeverywhere="false">
@@ -1273,12 +1288,17 @@
       <Sound file="Mods/Advanced Medicine/Sound/pump.ogg" range="500" />
     </StatusEffect>
     <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="cpr_buff" damagemultiplier="0.0" damagesound="LimbArmor"/>
+<<<<<<< Updated upstream
       <sprite name="Auto-Compression" texture="Mods/Advanced Medicine/Images/InGameItemIconAtlas.png" limb="Torso" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+=======
+      <sprite name="AutoPulse" texture="Mods/Advanced Medicine/Images/InGameItemIconAtlas.png" limb="Torso" hidelimb="true" inherittexturescale="true" sourcerect="640,0,128,128" origin="0.5,0.6" />
+>>>>>>> Stashed changes
     </Wearable>
     <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
       <Containable items="mobilebattery" />
     </ItemContainer>
   </Item>
+
   <Override>
   <Item name="" identifier="antibloodloss1" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
@@ -1325,6 +1345,7 @@
     <AiTarget sightrange="1000" static="true" />
   </Item>
   </Override>
+
   <Override>
   <Item name="Blood Pack O-" identifier="antibloodloss2" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
@@ -1877,6 +1898,7 @@
     <ItemContainer capacity="5" canbeselected="true" hideitems="true" slotsperrow="5" uilabel="" allowuioverlap="true"/>
     <ItemContainer capacity="1" canbeselected="true" hideitems="true" slotsperrow="1" uilabel="" allowuioverlap="true"/>
   </Item> 
+
   <Override>
   <Item name="" identifier="idcard" category="Equipment" Tags="smallitem,idcard" cargocontaineridentifier="metalcrate">
     <Price baseprice="10" soldeverywhere="false" />
@@ -1889,6 +1911,7 @@
     </ItemContainer>
   </Item>
   </Override>
+
   <Item name="Doner card" identifier="ominuscard" category="Equipment" description="Blood group O-" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
     <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
     <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
@@ -2005,7 +2028,35 @@
     <Body width="35" height="70" density="20" />
     <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
   </Item>
+<<<<<<< Updated upstream
   <Item name="Blood analyzer" description="Blood typing device" identifier="bloodanalyzer" category="Equipment" useinhealthinterface="true" cargocontaineridentifier="metalcrate" tags="smallitem" impactsoundtag="impact_soft" scale="0.5" hideconditionbar="true">
+=======
+
+  <Item name="" identifier="vialrack" scale="0.2" category="Equipment" description="Rack for storing blood collectors and vials" cargocontaineridentifier="metalcrate">
+    <Price baseprice="10">
+      <Price locationtype="outpost" multiplier="1" minavailable="2" />
+      <Price locationtype="city" multiplier="0.9" minavailable="6" />
+      <Price locationtype="research" multiplier="0.9" minavailable="10" />
+      <Price locationtype="military" multiplier="1" minavailable="10" />
+      <Price locationtype="mine" multiplier="0.75" minavailable="2" />
+    </Price>
+    <Fabricate suitablefabricators="medicalfabricator" requiredtime="5" >
+      <RequiredSkill identifier="medical" level="20" />
+      <RequiredItem identifier="plastic" mincondition="1" usecondition="true"/>
+    </Fabricate>
+
+    <InventoryIcon texture="Mods/Advanced Medicine/Images/InventoryItemIconAtlas.png" sourcerect="64,128,64,64" origin="0.5,0.5"/>
+    <Sprite texture="Mods/Advanced Medicine/Images/InGameItemIconAtlas.png" sourcerect="512,128,128,128" depth="0.6" origin="0.5,0.5" />
+
+    <Body width="35" height="70" density="20" />
+    <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+    <ItemContainer capacity="50" maxstacksize="1" hideitems="true">
+        <Containable items="vial" />
+    </ItemContainer>
+  </Item>
+
+  <Item name="" identifier="bloodanalyzer" description=""  category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem" impactsoundtag="impact_soft" scale="0.5" hideconditionbar="true">
+>>>>>>> Stashed changes
     <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
     <Sprite texture="Content/Items/Tools/tools.png" sourcerect="227,163,48,24" depth="0.55" origin="0.5,0.5" />
     <Body width="40" height="22" density="40" />


### PR DESCRIPTION
**Auto-Compression** renamed to **AutoPulse**. This should reduce misunderstandings with "Auto-what... What should I do...?"
Kinda placeholder name but there is no other devices except AutoPulse created by _Revivant_ . 

**autocpt** tag changed to **autocpr**. Probably a typo, but there is no more tags includes **autocpt**, so I took a risk. Less typos - less problems.

Some minor changes regarding the blood system, but it's going to be changed so nevermind. 
Blitzround:

- **Vial rack** => **Test tube rack**. Because "vial" is a small glass or plastic vessel or bottle. Barotrauma medicines and antidotes are much closer to "vials".
- **Blood collector** => **Test tube**.
- **Blood analyzer** => **Hematology analyzer** (we're still debating)
- Basic items descriptions were changed except items with no description at all and items that do not need descriptions (Blood type, Donor card)
