### PR TITLE
Refactored `antibloodloss2`, added `bloodpackominus`, slight rebalance

### DIFF
--- a/Advanced Medicine/Localization/English/English.xml
+++ b/Advanced Medicine/Localization/English/English.xml
@@ -71,8 +71,8 @@
 	<entityname.bloodpackoplus>Blood Pack O+</entityname.bloodpackoplus>
 	<!-- <entitydescription.bloodpackoplus></entitydescription.bloodpackoplus> -->
 
-	<entityname.antibloodloss2>Blood Pack O-</entityname.antibloodloss2>
-	<!-- <entitydescription.antibloodloss2></entitydescription.antibloodloss2> -->
+	<entityname.bloodpackominus>Blood Pack O-</entityname.bloodpackominus>
+	<!-- <entitydescription.bloodpackominus></entitydescription.bloodpackominus> -->
 
 	<entityname.bloodpackaplus>Blood Pack A+</entityname.bloodpackaplus>
 	<!-- <entitydescription.bloodpackaplus></entitydescription.bloodpackaplus> -->
@@ -91,9 +91,13 @@
 
 	<entityname.bloodpackabminus>Blood Pack AB-</entityname.bloodpackabminus>
 	<!-- <entitydescription.bloodpackabminus></entitydescription.bloodpackabminus> -->
-
+	
 	<entityname.antibloodloss3>Filtered Blood Pack</entityname.antibloodloss3>
+	<!-- (this one is deprecated) -->
 	<!-- <entitydescription.antibloodloss3></entitydescription.antibloodloss3> -->
+	
+	<entityname.antibloodloss2>Filtered Blood Pack</entityname.antibloodloss2>
+	<!-- <entitydescription.antibloodloss2></entitydescription.antibloodloss2> -->
 
 	<entityname.antiseptic>Antiseptic</entityname.antiseptic>
 	<!-- <entitydescription.antiseptic></entitydescription.antiseptic> -->

--- a/Advanced Medicine/Xml/items.xml
+++ b/Advanced Medicine/Xml/items.xml
@@ -2043,76 +2043,125 @@
         <Item name="" identifier="antibloodloss2" category="Material" maxstacksize="8"
               cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true"
               description="" scale="0.5" impactsoundtag="impact_soft">
-            <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-            <PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.5"/>
-            <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
-            <Price baseprice="300">
-                <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-                <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-                <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-                <Price locationtype="military" multiplier="1" minavailable="10"/>
-                <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-            </Price>
-            <Fabricate suitablefabricators="medicalfabricator" requiredtime="25">
-                <RequiredSkill identifier="medical" level="31"/>
-                <RequiredItem identifier="alienblood"/>
-                <RequiredItem identifier="antibloodloss1"/>
-                <RequiredItem identifier="stabilozine"/>
-            </Fabricate>
-            <Deconstruct time="20">
-                <Item identifier="alienblood" copycondition="true" mincondition="0.1"/>
-                <Item identifier="antibloodloss1" copycondition="true" mincondition="0.1"/>
-                <Item identifier="stabilozine" copycondition="true" mincondition="0.1"/>
-            </Deconstruct>
-            <SuitableTreatment identifier="bloodloss" suitability="120"/>
-            <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="128,85,64,85"
-                           origin="0.5,0.5"/>
-            <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="128,85,64,85" depth="0.6"
-                    origin="0.5,0.5"/>
-            <Body width="80" height="42" density="11"/>
-            <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                      msg="ItemMsgPickUpSelect">
-                <RequiredSkill identifier="medical" level="35"/>
-                <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
-                <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-                <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
-                    <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-                    <ReduceAffliction identifier="bloodloss" amount="3"/>
-                </StatusEffect>
-                <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
-                    <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-                    <ReduceAffliction identifier="bloodloss" amount="2"/>
-                </StatusEffect>
-                <!-- Remove the item when fully used -->
-                <StatusEffect type="OnBroken" target="This">
-                    <Remove/>
-                </StatusEffect>
-            </Holdable>
+			<PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.5"/>
+			<PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
+			<Price baseprice="300">
+				<Price locationtype="outpost" multiplier="1" minavailable="2"/>
+				<Price locationtype="city" multiplier="0.9" minavailable="6"/>
+				<Price locationtype="research" multiplier="0.9" minavailable="10"/>
+				<Price locationtype="military" multiplier="1" minavailable="10"/>
+				<Price locationtype="mine" multiplier="0.75" minavailable="2"/>
+			</Price>
+			<Fabricate suitablefabricators="medicalfabricator" requiredtime="25">
+				<RequiredSkill identifier="medical" level="31"/>
+				<RequiredItem identifier="alienblood"/>
+				<RequiredItem identifier="antibloodloss1"/>
+				<RequiredItem identifier="stabilozine"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackabminus"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackabplus"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackaminus"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackaplus"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackbminus"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackbplus"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackominus"/>
+			</Fabricate>
+			<Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
+				<RequiredSkill identifier="medical" level="40"/>
+				<RequiredItem identifier="bloodpackoplus"/>
+			</Fabricate>
+			<Deconstruct time="20">
+				<Item identifier="alienblood" copycondition="true" mincondition="0.1"/>
+				<Item identifier="antibloodloss1" copycondition="true" mincondition="0.1"/>
+				<Item identifier="stabilozine" copycondition="true" mincondition="0.1"/>
+			</Deconstruct>
+			<SuitableTreatment identifier="bloodloss" suitability="100"/>
+			<Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="192,85,64,85" depth="0.6"
+					origin="0.5,0.5"/>
+			<Body width="80" height="42" density="11"/>
+			<Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
+					  msg="ItemMsgPickUpSelect">
+				<RequiredSkill identifier="medical" level="35"/>
+				<StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
+				<StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+				<StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
+					<Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+					<ReduceAffliction identifier="bloodloss" amount="3"/>
+					<Affliction identifier="nausea" amount="6"/>
+				</StatusEffect>
+				<StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
+					<Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+					<ReduceAffliction identifier="bloodloss" amount="2"/>
+					<Affliction identifier="nausea" amount="8"/>
+				</StatusEffect>
+				<!-- Remove the item when fully used -->
+				<StatusEffect type="OnBroken" target="This">
+					<Remove/>
+				</StatusEffect>
+			</Holdable>
             <AiTarget sightrange="1000" static="true"/>
         </Item>
     </Override>
+	
+    <Item name="" identifier="bloodpackominus" variantof="antibloodloss2">
+        <PreferredContainer/>
+        <PreferredContainer/>
+		<PreferredContainer primary="medcab" />
+		<PreferredContainer primary="outpostmedcompartment" />
+        <Price baseprice="300" />
+		<Fabricate/>
+		<Fabricate/>
+		<Fabricate/>
+		<Fabricate/>
+		<Fabricate/>
+		<Fabricate/>
+		<Fabricate/>
+		<Fabricate/>
+		<Deconstruct/>
+		<!-- The texture path isn't required in `variantof` but it's better to play it safe than risk making a variant of the unmodified vanilla parent, once the game loads this mod before vanilla files due to an error -->
+		<Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="128,85,64,85" />
+		<Holdable>
+			<StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
+			<StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+			<StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
+				<Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+				<ReduceAffliction identifier="bloodloss" amount="3"/>
+			</StatusEffect>
+			<StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
+				<Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+				<ReduceAffliction identifier="bloodloss" amount="2"/>
+			</StatusEffect>
+			<!-- Remove the item when fully used -->
+			<StatusEffect type="OnBroken" target="This">
+				<Remove/>
+			</StatusEffect>
+		</Holdable>
+    </Item>
 
-    <Item name="" identifier="bloodpackoplus" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true" description="" scale="0.5"
-          impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.5"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
-        <Price baseprice="250">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="128,171,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="128,171,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <RequiredSkill identifier="medical" level="35"/>
+    <Item name="" identifier="bloodpackoplus" variantof="bloodpackominus">
+        <Price baseprice="250" />
+        <Sprite sourcerect="128,171,64,85" />
+        <Holdable>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
@@ -2138,27 +2187,10 @@
         </Holdable>
     </Item>
 
-    <Item name="" identifier="bloodpackaplus" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true" description="" scale="0.5"
-          impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.25"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
-        <Price baseprice="180">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="64,0,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="64,0,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <RequiredSkill identifier="medical" level="35"/>
+    <Item name="" identifier="bloodpackaplus" variantof="bloodpackominus">
+        <Price baseprice="180" />
+        <Sprite sourcerect="64,0,64,85" />
+        <Holdable>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
@@ -2184,27 +2216,10 @@
         </Holdable>
     </Item>
 
-    <Item name="" identifier="bloodpackbplus" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true" description="" scale="0.5"
-          impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.25"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
-        <Price baseprice="180">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="64,171,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="64,171,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <RequiredSkill identifier="medical" level="35"/>
+    <Item name="" identifier="bloodpackbplus" variantof="bloodpackominus">
+        <Price baseprice="180" />
+        <Sprite sourcerect="64,171,64,85" />
+        <Holdable>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
@@ -2230,25 +2245,10 @@
         </Holdable>
     </Item>
 
-    <Item name="" identifier="bloodpackabplus" category="Material" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true"
-          description="" scale="0.5" impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <Price baseprice="125">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="0,0,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="0,0,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <RequiredSkill identifier="medical" level="35"/>
+    <Item name="" identifier="bloodpackabplus" variantof="bloodpackominus">
+        <Price baseprice="125" />
+        <Sprite sourcerect="0,0,64,85" />
+        <Holdable>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
@@ -2276,27 +2276,10 @@
         </Holdable>
     </Item>
 
-    <Item name="" identifier="bloodpackaminus" category="Material" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true"
-          description="" scale="0.5" impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.25"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
-        <Price baseprice="210">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="192,171,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="192,171,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <RequiredSkill identifier="medical" level="35"/>
+    <Item name="" identifier="bloodpackaminus"  variantof="bloodpackominus">
+        <Price baseprice="210" />
+        <Sprite sourcerect="192,171,64,85" />
+        <Holdable>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
@@ -2322,27 +2305,10 @@
         </Holdable>
     </Item>
 
-    <Item name="" identifier="bloodpackbminus" category="Material" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true"
-          description="" scale="0.5" impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.25"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
-        <Price baseprice="195">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="128,0,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="128,0,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <RequiredSkill identifier="medical" level="35"/>
+    <Item name="" identifier="bloodpackbminus"  variantof="bloodpackominus">
+        <Price baseprice="195" />
+        <Sprite sourcerect="128,0,64,85" />
+        <Holdable>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
@@ -2368,24 +2334,10 @@
         </Holdable>
     </Item>
 
-    <Item name="" identifier="bloodpackabminus" category="Material" maxstacksize="8"
-          cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true"
-          description="" scale="0.5" impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <Price baseprice="150">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="64,85,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="64,85,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
+    <Item name="" identifier="bloodpackabminus"  variantof="bloodpackominus">
+        <Price baseprice="150" />
+        <Sprite sourcerect="64,85,64,85" />
+        <Holdable>
             <RequiredSkill identifier="medical" level="35"/>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
@@ -2411,80 +2363,47 @@
             </StatusEffect>
         </Holdable>
     </Item>
-    <Item name="" identifier="antibloodloss3" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
-          Tags="smallitem,chem,medical,petfood1" useinhealthinterface="true" description="" scale="0.5"
-          impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <PreferredContainer primary="medcab" minamount="2" maxamount="3" spawnprobability="0.5"/>
-        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.15"/>
-        <Price baseprice="300">
-            <Price locationtype="outpost" multiplier="1" minavailable="2"/>
-            <Price locationtype="city" multiplier="0.9" minavailable="6"/>
-            <Price locationtype="research" multiplier="0.9" minavailable="10"/>
-            <Price locationtype="military" multiplier="1" minavailable="10"/>
-            <Price locationtype="mine" multiplier="0.75" minavailable="2"/>
-        </Price>
-        <Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="bloodpackabminus"/>
-        </Fabricate>
-        <Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="bloodpackabplus"/>
-        </Fabricate>
-        <Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="bloodpackaminus"/>
-        </Fabricate>
-        <Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="bloodpackaplus"/>
-        </Fabricate>
-        <Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="bloodpackbminus"/>
-        </Fabricate>
-        <Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="bloodpackbplus"/>
-        </Fabricate>
-        <Fabricate suitablefabricators="bloodrefinery" requiredtime="40">
-            <RequiredSkill identifier="medical" level="40"/>
-            <RequiredItem identifier="bloodpackoplus"/>
-        </Fabricate>
-        <SuitableTreatment identifier="bloodloss" suitability="100"/>
-        <InventoryIcon texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="192,85,64,85"
-                       origin="0.5,0.5"/>
-        <Sprite texture="Mods/Advanced Medicine/Images/BloodPacksAtlas.png" sourcerect="192,85,64,85" depth="0.6"
-                origin="0.5,0.5"/>
-        <Body width="80" height="42" density="11"/>
-        <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0"
-                  msg="ItemMsgPickUpSelect">
-            <RequiredSkill identifier="medical" level="35"/>
-            <StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
-            <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
-            <StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
-                <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-                <ReduceAffliction identifier="bloodloss" amount="3"/>
-                <Affliction identifier="nausea" amount="6"/>
-            </StatusEffect>
-            <StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
-                <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
-                <ReduceAffliction identifier="bloodloss" amount="2"/>
-                <Affliction identifier="nausea" amount="8"/>
-            </StatusEffect>
-            <!-- Remove the item when fully used -->
-            <StatusEffect type="OnBroken" target="This">
-                <Remove/>
-            </StatusEffect>
-        </Holdable>
-        <AiTarget sightrange="1000" static="true"/>
+	
+	<!-- DEPRECATED, DO NOT REMOVE because of potential saves that still use this identifier. 
+	Has the same functino as `antibloodloss2`. It could remove itself and spawn `antibloodloss2` in its place but if it did, `antibloodloss2` would drop on the ground from inventories which could be annoying on custom subs that support AM. -->
+    <Item name="" identifier="antibloodloss3" variantof="bloodpackominus" hideinmenus="true">
+		<Price baseprice="300">
+			<Price locationtype="outpost" multiplier="1" sold="false"/>
+			<Price locationtype="city" multiplier="0.9" sold="false"/>
+			<Price locationtype="research" multiplier="0.9" sold="false"/>
+			<Price locationtype="military" multiplier="1" sold="false"/>
+			<Price locationtype="mine" multiplier="0.75" sold="false"/>
+		</Price>
+		<Deconstruct time="20">
+			<Item identifier="alienblood" copycondition="true" mincondition="0.1"/>
+			<Item identifier="antibloodloss1" copycondition="true" mincondition="0.1"/>
+			<Item identifier="stabilozine" copycondition="true" mincondition="0.1"/>
+		</Deconstruct>
+		<Sprite sourcerect="192,85,64,85" />
+		<Holdable>
+			<StatusEffect type="OnFailure" target="This" Condition="-100.0" disabledeltatime="true"/>
+			<StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+			<StatusEffect tags="medical" type="OnUse" target="Character, This" duration="11">
+				<Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+				<ReduceAffliction identifier="bloodloss" amount="3"/>
+				<Affliction identifier="nausea" amount="6"/>
+			</StatusEffect>
+			<StatusEffect tags="medical" type="OnFailure" target="Character, This" duration="11">
+				<Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+				<ReduceAffliction identifier="bloodloss" amount="2"/>
+				<Affliction identifier="nausea" amount="8"/>
+			</StatusEffect>
+			<!-- Remove the item when fully used -->
+			<StatusEffect type="OnBroken" target="This">
+				<Remove/>
+			</StatusEffect>
+		</Holdable>
     </Item>
 
     <Item name="" identifier="emptybloodpack" category="Material" maxstacksize="8" cargocontaineridentifier="mediccrate"
           Tags="smallitem,chem,medical" useinhealthinterface="true" description="" scale="0.5"
           impactsoundtag="impact_soft">
-        <Upgrade gameversion="0.10.0.0" scale="0.5"/>
+		<PreferredContainer primary="medcab" minamount="1" maxamount="2" spawnprobability="1"/>
         <Price baseprice="25">
             <Price locationtype="outpost" multiplier="1" minavailable="2"/>
             <Price locationtype="city" multiplier="0.9" minavailable="6"/>


### PR DESCRIPTION
Formatting:
- converted all blood packs (except for empty ones) to `variantof` format
- refactored `antibloodloss2` into filtered blood (previously `antibloodloss2` it was O-) so that filtered blood is the default vanilla blood pack
- added `bloodpackominus` (and added it to filtered blood recipes)
- deprecated `antibloodloss3`

In other words:
- previous O- was refactored into new Filtered Blood
- previous Filtered Blood was deprecated (can still be used, can't be crafted/bought/spawned/looted)
- added a new O- item
- new Filtered Blood is exactly the same as old Filtered Blood but has a new identifier

Balance:
- removed spawn probability of all blood types (except for filtered blood). The reasoning is that blood types can't be stored for prolonged periods of time (waiting for fridges...)
- added spawnprobability for empty blood packs (was missing)
- removed deconstructing recipes from all blood types (except for filtered blood). The reasoning (agreed by the community) is that you can't "deconstruct" blood types without filtering them first.

Important: Alien Blood + Saline + Stabilozine now crafts Filtered Blood instead of O-. The reasoning is that you can't reasonably fabricate antibodies but you can fabricate filtered, clean blood.

Localization:
- `antibloodloss2` became Filtered Blood Pack
- `antibloodloss3` wasn't changed (deprecated but usable)
- added `bloodpackominus`